### PR TITLE
Add Budget Expense Categories APIs

### DIFF
--- a/src/apis/budget/Budget.API/Endpoints/ExpenseCategories/Create.cs
+++ b/src/apis/budget/Budget.API/Endpoints/ExpenseCategories/Create.cs
@@ -1,0 +1,25 @@
+﻿namespace Budget.API.Endpoints.ExpenseCategories;
+
+public class Create : IEndpoint
+{
+    public sealed record CreateExpenseCategoryRequest(string Name, string Description, string? ParentCategoryId = null);
+
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPost("expense-categories", async (CreateExpenseCategoryRequest request, IUserContext userContext, ISender sender, LinkGenerator linkGenerator, CancellationToken cancellationToken) =>
+        {
+            CreateExpenseCategoryCommand command = new(userContext.UserId, request.Name, request.Description, request.ParentCategoryId);
+            Guid newId = await sender.Send(command, cancellationToken);
+
+            var result = new { id = newId };
+            string? locationUrl = linkGenerator.GetPathByName("GetExpenseCategoryById", result);
+
+            return Results.Created(locationUrl, result);
+        })
+        .WithTags("Expense Categories")
+        .Produces<SuccessResponse>(StatusCodes.Status201Created)
+        .Produces<ErrorResponse>(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces<ErrorResponse>(StatusCodes.Status500InternalServerError);
+    }
+}

--- a/src/apis/budget/Budget.API/Endpoints/ExpenseCategories/Create.cs
+++ b/src/apis/budget/Budget.API/Endpoints/ExpenseCategories/Create.cs
@@ -1,6 +1,6 @@
 ﻿namespace Budget.API.Endpoints.ExpenseCategories;
 
-public class Create : IEndpoint
+internal sealed class Create : IEndpoint
 {
     public sealed record CreateExpenseCategoryRequest(string Name, string Description, string? ParentCategoryId = null);
 

--- a/src/apis/budget/Budget.API/Endpoints/ExpenseCategories/Delete.cs
+++ b/src/apis/budget/Budget.API/Endpoints/ExpenseCategories/Delete.cs
@@ -1,0 +1,19 @@
+﻿namespace Budget.API.Endpoints.ExpenseCategories;
+
+internal sealed class Delete : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapDelete("expense-categories/{id:guid}", async (Guid id, ISender sender, CancellationToken cancellationToken) => 
+        {
+            DeleteExpenseCategoryCommand command = new(id);
+            await sender.Send(command, cancellationToken);
+            return Results.NoContent();
+        })
+        .WithTags("Expense Categories")
+        .Produces(StatusCodes.Status204NoContent)
+        .Produces<ErrorResponse>(StatusCodes.Status404NotFound)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces<ErrorResponse>(StatusCodes.Status500InternalServerError);
+    }
+}

--- a/src/apis/budget/Budget.API/Endpoints/ExpenseCategories/GetAll.cs
+++ b/src/apis/budget/Budget.API/Endpoints/ExpenseCategories/GetAll.cs
@@ -1,0 +1,18 @@
+﻿namespace Budget.API.Endpoints.ExpenseCategories;
+
+internal sealed class GetAll : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("expense-categories", async (ISender sender, CancellationToken cancellationToken) => 
+        {
+            GetExpenseCategoriesQuery query = new();
+            List<ExpenseCategorySummaryDto> categories = await sender.Send(query, cancellationToken); 
+            return Results.Ok(categories);
+        })
+        .WithTags("Expense Categories")
+        .Produces<ExpenseCategorySummaryDto[]>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces<ErrorResponse>(StatusCodes.Status500InternalServerError);
+    }
+}

--- a/src/apis/budget/Budget.API/Endpoints/ExpenseCategories/GetById.cs
+++ b/src/apis/budget/Budget.API/Endpoints/ExpenseCategories/GetById.cs
@@ -1,0 +1,19 @@
+﻿namespace Budget.API.Endpoints.ExpenseCategories;
+
+internal sealed class GetById : IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("expense-categories/{id:guid}", async (Guid id, ISender sender, CancellationToken cancellationToken) => 
+        {
+            ExpenseCategoryDetailDto expense = await sender.Send(new GetExpenseCategoryByIdQuery(id), cancellationToken);
+            return Results.Ok(expense);
+        })
+        .WithTags("Expense Categories")
+        .WithName("GetExpenseCategoryById")
+        .Produces<ExpenseCategoryDetailDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces<ErrorResponse>(StatusCodes.Status404NotFound)
+        .Produces<ErrorResponse>(StatusCodes.Status500InternalServerError);
+    }
+}

--- a/src/apis/budget/Budget.API/Endpoints/ExpenseCategories/Update.cs
+++ b/src/apis/budget/Budget.API/Endpoints/ExpenseCategories/Update.cs
@@ -1,0 +1,22 @@
+﻿namespace Budget.API.Endpoints.ExpenseCategories;
+
+internal sealed class Update : IEndpoint
+{
+    public sealed record UpdateExpenseCategoryRequest(Guid ExpenseCategoryId, string Name, string Description, string? ParentCategoryId = null);
+
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapPut("expense-categories/{id:guid}", async (Guid id, UpdateExpenseCategoryRequest request, IUserContext userContext, ISender sender, CancellationToken cancellationToken) => 
+        {
+            UpdateExpenseCategoryCommand command = new(id, userContext.UserId, request.Name, request.Description, request.ParentCategoryId);
+            await sender.Send(command, cancellationToken);
+            return Results.NoContent();
+        })
+        .WithTags("Expense Categories")
+        .Produces(StatusCodes.Status204NoContent)
+        .Produces<ErrorResponse>(StatusCodes.Status400BadRequest)
+        .Produces<ErrorResponse>(StatusCodes.Status404NotFound)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces<ErrorResponse>(StatusCodes.Status500InternalServerError);
+    }
+}

--- a/src/apis/budget/Budget.API/Endpoints/Expenses/Create.cs
+++ b/src/apis/budget/Budget.API/Endpoints/Expenses/Create.cs
@@ -16,6 +16,7 @@ internal sealed class Create : IEndpoint
 
             return Results.Created(locationUrl, result);
         })
+        .WithTags("Expenses")
         .Produces<SuccessResponse>(StatusCodes.Status201Created)
         .Produces<ErrorResponse>(StatusCodes.Status400BadRequest)
         .Produces(StatusCodes.Status401Unauthorized)

--- a/src/apis/budget/Budget.API/Endpoints/Expenses/Create.cs
+++ b/src/apis/budget/Budget.API/Endpoints/Expenses/Create.cs
@@ -6,13 +6,13 @@ internal sealed class Create : IEndpoint
 
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapPost("expenses", async (CreateExpenseRequest request, HttpContext httpContext, LinkGenerator linkGenerator, IUserContext userContext, ISender sender, CancellationToken cancelationToken) =>
+        app.MapPost("expenses", async (CreateExpenseRequest request, HttpContext httpContext, LinkGenerator linkGenerator, IUserContext userContext, ISender sender, CancellationToken cancellationToken) =>
         {
             CreateExpenseCommand command = new(userContext.UserId, request.Amount, request.Currency, request.Date, request.Description, request.CategoryId);
-            Guid newId = await sender.Send(command, cancelationToken);
+            Guid newId = await sender.Send(command, cancellationToken);
 
             var result = new { id = newId };
-            string? locationUrl = linkGenerator.GetPathByName("GetItemById", result);
+            string? locationUrl = linkGenerator.GetPathByName("GetExpenseById", result);
 
             return Results.Created(locationUrl, result);
         })

--- a/src/apis/budget/Budget.API/Endpoints/Expenses/Delete.cs
+++ b/src/apis/budget/Budget.API/Endpoints/Expenses/Delete.cs
@@ -10,6 +10,7 @@ public class Delete : IEndpoint
             await sender.Send(command, cancellationToken);
             return Results.NoContent();
         })
+        .WithTags("Expenses")
         .Produces(StatusCodes.Status204NoContent)
         .Produces<ErrorResponse>(StatusCodes.Status404NotFound)
         .Produces(StatusCodes.Status401Unauthorized)

--- a/src/apis/budget/Budget.API/Endpoints/Expenses/GetAll.cs
+++ b/src/apis/budget/Budget.API/Endpoints/Expenses/GetAll.cs
@@ -4,9 +4,9 @@ internal sealed class GetAll : IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapGet("expenses", async (IUserContext userContext, ISender sender, HttpContext httpContext, CancellationToken cancellation) =>
+        app.MapGet("expenses", async (IUserContext userContext, ISender sender, HttpContext httpContext, CancellationToken cancellationToken) =>
         {
-            List<ExpenseSummaryDto> expenses = await sender.Send(new GetExpensesQuery(userContext.UserId), cancellation);
+            List<ExpenseSummaryDto> expenses = await sender.Send(new GetExpensesQuery(userContext.UserId), cancellationToken);
             return Results.Ok(expenses);
         })
         .WithTags("Expenses")

--- a/src/apis/budget/Budget.API/Endpoints/Expenses/GetAll.cs
+++ b/src/apis/budget/Budget.API/Endpoints/Expenses/GetAll.cs
@@ -9,6 +9,7 @@ internal sealed class GetAll : IEndpoint
             List<ExpenseSummaryDto> expenses = await sender.Send(new GetExpensesQuery(userContext.UserId), cancellation);
             return Results.Ok(expenses);
         })
+        .WithTags("Expenses")
         .Produces<ExpenseSummaryDto[]>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized)
         .Produces<ErrorResponse>(StatusCodes.Status500InternalServerError);

--- a/src/apis/budget/Budget.API/Endpoints/Expenses/GetById.cs
+++ b/src/apis/budget/Budget.API/Endpoints/Expenses/GetById.cs
@@ -4,9 +4,9 @@ internal sealed class GetById : IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapGet("expenses/{id:guid}", async (Guid id, IUserContext userContext, ISender sender) =>
+        app.MapGet("expenses/{id:guid}", async (Guid id, IUserContext userContext, ISender sender, CancellationToken cancellationToken) =>
         {
-            ExpenseDetailDto expense = await sender.Send(new GetExpenseByIdQuery(userContext.UserId, id));
+            ExpenseDetailDto expense = await sender.Send(new GetExpenseByIdQuery(userContext.UserId, id), cancellationToken);
             return Results.Ok(expense);
         })
         .WithTags("Expenses")

--- a/src/apis/budget/Budget.API/Endpoints/Expenses/GetById.cs
+++ b/src/apis/budget/Budget.API/Endpoints/Expenses/GetById.cs
@@ -9,6 +9,7 @@ internal sealed class GetById : IEndpoint
             ExpenseDetailDto expense = await sender.Send(new GetExpenseByIdQuery(userContext.UserId, id));
             return Results.Ok(expense);
         })
+        .WithTags("Expenses")
         .WithName("GetExpenseById")
         .Produces<ExpenseSummaryDto>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status401Unauthorized)

--- a/src/apis/budget/Budget.API/Endpoints/Expenses/Update.cs
+++ b/src/apis/budget/Budget.API/Endpoints/Expenses/Update.cs
@@ -12,6 +12,7 @@ internal sealed class Update : IEndpoint
             await sender.Send(command, cancellationToken);
             return Results.NoContent();
         })
+        .WithTags("Expenses")
         .Produces(StatusCodes.Status204NoContent)
         .Produces<ErrorResponse>(StatusCodes.Status400BadRequest)
         .Produces<ErrorResponse>(StatusCodes.Status404NotFound)

--- a/src/apis/budget/Budget.API/GlobalUsings.cs
+++ b/src/apis/budget/Budget.API/GlobalUsings.cs
@@ -3,6 +3,7 @@ global using Budget.API.Middlewares;
 global using Budget.API.Registrars;
 global using Budget.Application.Abstractions;
 global using Budget.Application.ExpenseCategories;
+global using Budget.Application.ExpenseCategories.Create;
 global using Budget.Application.ExpenseCategories.GetAll;
 global using Budget.Application.ExpenseCategories.GetById;
 global using Budget.Application.Expenses;
@@ -28,4 +29,3 @@ global using Shared.Common.Settings;
 global using Shared.Http.Responses;
 global using System.Text;
 global using System.Text.Json;
-

--- a/src/apis/budget/Budget.API/GlobalUsings.cs
+++ b/src/apis/budget/Budget.API/GlobalUsings.cs
@@ -2,6 +2,8 @@
 global using Budget.API.Middlewares;
 global using Budget.API.Registrars;
 global using Budget.Application.Abstractions;
+global using Budget.Application.ExpenseCategories;
+global using Budget.Application.ExpenseCategories.GetAll;
 global using Budget.Application.Expenses;
 global using Budget.Application.Expenses.Create;
 global using Budget.Application.Expenses.Delete;
@@ -11,6 +13,7 @@ global using Budget.Application.Expenses.Update;
 global using Budget.Domain.Expenses;
 global using Budget.Infrastructure.Authentication;
 global using Budget.Infrastructure.Database;
+global using Budget.Infrastructure.ExpenseCategories;
 global using Budget.Infrastructure.Expenses;
 global using FluentValidation;
 global using MediatR;

--- a/src/apis/budget/Budget.API/GlobalUsings.cs
+++ b/src/apis/budget/Budget.API/GlobalUsings.cs
@@ -4,6 +4,7 @@ global using Budget.API.Registrars;
 global using Budget.Application.Abstractions;
 global using Budget.Application.ExpenseCategories;
 global using Budget.Application.ExpenseCategories.Create;
+global using Budget.Application.ExpenseCategories.Delete;
 global using Budget.Application.ExpenseCategories.GetAll;
 global using Budget.Application.ExpenseCategories.GetById;
 global using Budget.Application.ExpenseCategories.Update;

--- a/src/apis/budget/Budget.API/GlobalUsings.cs
+++ b/src/apis/budget/Budget.API/GlobalUsings.cs
@@ -6,6 +6,7 @@ global using Budget.Application.ExpenseCategories;
 global using Budget.Application.ExpenseCategories.Create;
 global using Budget.Application.ExpenseCategories.GetAll;
 global using Budget.Application.ExpenseCategories.GetById;
+global using Budget.Application.ExpenseCategories.Update;
 global using Budget.Application.Expenses;
 global using Budget.Application.Expenses.Create;
 global using Budget.Application.Expenses.Delete;

--- a/src/apis/budget/Budget.API/GlobalUsings.cs
+++ b/src/apis/budget/Budget.API/GlobalUsings.cs
@@ -4,6 +4,7 @@ global using Budget.API.Registrars;
 global using Budget.Application.Abstractions;
 global using Budget.Application.ExpenseCategories;
 global using Budget.Application.ExpenseCategories.GetAll;
+global using Budget.Application.ExpenseCategories.GetById;
 global using Budget.Application.Expenses;
 global using Budget.Application.Expenses.Create;
 global using Budget.Application.Expenses.Delete;
@@ -27,3 +28,4 @@ global using Shared.Common.Settings;
 global using Shared.Http.Responses;
 global using System.Text;
 global using System.Text.Json;
+

--- a/src/apis/budget/Budget.API/Registrars/DbContextRegistrar.cs
+++ b/src/apis/budget/Budget.API/Registrars/DbContextRegistrar.cs
@@ -15,5 +15,6 @@ public sealed class DbContextRegistrar : IRegistrar
         }, ServiceLifetime.Scoped);
 
         services.AddScoped<IExpenseDbContext, BudgetDbContext>();
+        services.AddScoped<IExpenseCategoryDbContext, BudgetDbContext>();
     }
 }

--- a/src/apis/budget/Budget.API/Registrars/ServiceRegistrar.cs
+++ b/src/apis/budget/Budget.API/Registrars/ServiceRegistrar.cs
@@ -6,5 +6,6 @@ public class ServiceRegistrar : IRegistrar
     {
         services.AddScoped<IUserContext, UserContext>();
         services.AddScoped<IExpenseRepository, ExpenseRepository>();
+        services.AddScoped<IExpenseCategoryRepository, ExpenseCategoryRepository>();
     }
 }

--- a/src/apis/budget/Budget.Application/ExpenseCategories/Create/CreateExpenseCategoryCommand.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/Create/CreateExpenseCategoryCommand.cs
@@ -1,0 +1,3 @@
+﻿namespace Budget.Application.ExpenseCategories.Create;
+
+public sealed record CreateExpenseCategoryCommand(Guid UserId, string Name, string Description, string? ParentCategoryId = null) : IRequest<Guid> { }

--- a/src/apis/budget/Budget.Application/ExpenseCategories/Create/CreateExpenseCategoryCommandHandler.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/Create/CreateExpenseCategoryCommandHandler.cs
@@ -1,0 +1,17 @@
+﻿namespace Budget.Application.ExpenseCategories.Create;
+
+public sealed class CreateExpenseCategoryCommandHandler(IExpenseCategoryDbContext dbContext) : IRequestHandler<CreateExpenseCategoryCommand, Guid>
+{
+    public async Task<Guid> Handle(CreateExpenseCategoryCommand request, CancellationToken cancellationToken)
+    {
+        Guid? parentCategoryId = !string.IsNullOrWhiteSpace(request.ParentCategoryId)
+            ? Guid.Parse(request.ParentCategoryId)
+            : null;
+        ExpenseCategory category = new(Guid.NewGuid(), request.Name, request.Description, request.UserId, parentCategoryId);
+
+        await dbContext.AddExpenseCategoryAsync(category);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return category.Id;
+    }
+}

--- a/src/apis/budget/Budget.Application/ExpenseCategories/Create/CreateExpenseCategoryValidator.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/Create/CreateExpenseCategoryValidator.cs
@@ -1,0 +1,21 @@
+﻿namespace Budget.Application.ExpenseCategories.Create;
+
+public sealed class CreateExpenseCategoryValidator : AbstractValidator<CreateExpenseCategoryCommand>
+{
+    public CreateExpenseCategoryValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User id cannot be empty");
+
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Name cannot be empty");
+
+        RuleFor(x => x.Description)
+            .NotEmpty().WithMessage("Description cannot be empty");
+
+        RuleFor(x => x.ParentCategoryId)
+            .Must(x => Guid.TryParse(x, out _))
+                .When(x => x.ParentCategoryId is not null)
+                .WithMessage("Invalid parent category id format");
+    }
+}

--- a/src/apis/budget/Budget.Application/ExpenseCategories/Delete/DeleteExpenseCategoryCommand.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/Delete/DeleteExpenseCategoryCommand.cs
@@ -1,0 +1,3 @@
+﻿namespace Budget.Application.ExpenseCategories.Delete;
+
+public sealed record DeleteExpenseCategoryCommand(Guid Id) : IRequest<Unit> { }

--- a/src/apis/budget/Budget.Application/ExpenseCategories/Delete/DeleteExpenseCategoryCommandHandler.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/Delete/DeleteExpenseCategoryCommandHandler.cs
@@ -1,0 +1,12 @@
+﻿namespace Budget.Application.ExpenseCategories.Delete;
+
+public sealed class DeleteExpenseCategoryCommandHandler(IExpenseCategoryDbContext dbContext) : IRequestHandler<DeleteExpenseCategoryCommand, Unit>
+{
+    public async Task<Unit> Handle(DeleteExpenseCategoryCommand request, CancellationToken cancellationToken)
+    {
+        await dbContext.DeleteExpenseCategoryAsync(request.Id);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/src/apis/budget/Budget.Application/ExpenseCategories/Delete/DeleteExpenseCategoryValidator.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/Delete/DeleteExpenseCategoryValidator.cs
@@ -1,0 +1,11 @@
+﻿namespace Budget.Application.ExpenseCategories.Delete;
+
+public sealed class DeleteExpenseCategoryValidator : AbstractValidator<DeleteExpenseCategoryCommand>
+{
+    public DeleteExpenseCategoryValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty()
+            .WithMessage("Expense category id cannot be empty");
+    }
+}

--- a/src/apis/budget/Budget.Application/ExpenseCategories/GetAll/ExpenseCategorySummaryDto.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/GetAll/ExpenseCategorySummaryDto.cs
@@ -1,0 +1,3 @@
+﻿namespace Budget.Application.ExpenseCategories.GetAll;
+
+public sealed record ExpenseCategorySummaryDto(Guid Id, string Name, string Description, Guid? ParentCategoryId = null);

--- a/src/apis/budget/Budget.Application/ExpenseCategories/GetAll/GetExpenseCategoriesQuery.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/GetAll/GetExpenseCategoriesQuery.cs
@@ -1,0 +1,3 @@
+﻿namespace Budget.Application.ExpenseCategories.GetAll;
+
+public sealed record GetExpenseCategoriesQuery() : IRequest<List<ExpenseCategorySummaryDto>> { }

--- a/src/apis/budget/Budget.Application/ExpenseCategories/GetAll/GetExpenseCategoriesQueryHandler.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/GetAll/GetExpenseCategoriesQueryHandler.cs
@@ -1,0 +1,7 @@
+﻿namespace Budget.Application.ExpenseCategories.GetAll;
+
+public sealed class GetExpenseCategoriesQueryHandler(IExpenseCategoryRepository repository) : IRequestHandler<GetExpenseCategoriesQuery, List<ExpenseCategorySummaryDto>>
+{
+    public async Task<List<ExpenseCategorySummaryDto>> Handle(GetExpenseCategoriesQuery request, CancellationToken cancellationToken) 
+        => await repository.GetAllAsync(cancellationToken);
+}

--- a/src/apis/budget/Budget.Application/ExpenseCategories/GetById/ExpenseCategoryDetailDto.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/GetById/ExpenseCategoryDetailDto.cs
@@ -1,0 +1,13 @@
+﻿namespace Budget.Application.ExpenseCategories.GetById;
+
+public record ExpenseCategoryDetailDto(
+    Guid Id, 
+    string Name, 
+    string Description, 
+    Guid CreatedBy, 
+    DateTime CreatedAt, 
+    Guid? UpdatedBy = null, 
+    DateTime? UpdatedAt = null, 
+    Guid? ParentCategoryId = 
+    null, string? 
+    ParentCategoryName = null);

--- a/src/apis/budget/Budget.Application/ExpenseCategories/GetById/GetExpenseCategoryByIdQuery.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/GetById/GetExpenseCategoryByIdQuery.cs
@@ -1,0 +1,3 @@
+﻿namespace Budget.Application.ExpenseCategories.GetById;
+
+public sealed record GetExpenseCategoryByIdQuery(Guid Id) : IRequest<ExpenseCategoryDetailDto> { }

--- a/src/apis/budget/Budget.Application/ExpenseCategories/GetById/GetExpenseCategoryByIdQueryHandler.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/GetById/GetExpenseCategoryByIdQueryHandler.cs
@@ -1,0 +1,7 @@
+﻿namespace Budget.Application.ExpenseCategories.GetById;
+
+public sealed class GetExpenseCategoryByIdQueryHandler(IExpenseCategoryRepository repository) : IRequestHandler<GetExpenseCategoryByIdQuery, ExpenseCategoryDetailDto>
+{
+    public async Task<ExpenseCategoryDetailDto> Handle(GetExpenseCategoryByIdQuery request, CancellationToken cancellationToken) => 
+        await repository.GetByIdAsync(request.Id, cancellationToken) ?? throw new NotFoundException($"Expense Category with id: {request.Id} not found");
+}

--- a/src/apis/budget/Budget.Application/ExpenseCategories/IExpenseCategoryDbContext.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/IExpenseCategoryDbContext.cs
@@ -1,0 +1,7 @@
+﻿namespace Budget.Application.ExpenseCategories;
+
+public interface IExpenseCategoryDbContext
+{
+    Task AddExpenseCategoryAsync(ExpenseCategory expenseCategory);
+    Task SaveChangesAsync(CancellationToken cancellationToken);
+}

--- a/src/apis/budget/Budget.Application/ExpenseCategories/IExpenseCategoryDbContext.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/IExpenseCategoryDbContext.cs
@@ -4,5 +4,6 @@ public interface IExpenseCategoryDbContext
 {
     Task AddExpenseCategoryAsync(ExpenseCategory expenseCategory);
     Task UpdateExpenseCategoryAsync(ExpenseCategory expenseCategory);
+    Task DeleteExpenseCategoryAsync(Guid expenseCategoryId);
     Task SaveChangesAsync(CancellationToken cancellationToken);
 }

--- a/src/apis/budget/Budget.Application/ExpenseCategories/IExpenseCategoryDbContext.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/IExpenseCategoryDbContext.cs
@@ -3,5 +3,6 @@
 public interface IExpenseCategoryDbContext
 {
     Task AddExpenseCategoryAsync(ExpenseCategory expenseCategory);
+    Task UpdateExpenseCategoryAsync(ExpenseCategory expenseCategory);
     Task SaveChangesAsync(CancellationToken cancellationToken);
 }

--- a/src/apis/budget/Budget.Application/ExpenseCategories/IExpenseCategoryRepository.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/IExpenseCategoryRepository.cs
@@ -3,4 +3,5 @@
 public interface IExpenseCategoryRepository
 {
     Task<List<ExpenseCategorySummaryDto>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<ExpenseCategoryDetailDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
 }

--- a/src/apis/budget/Budget.Application/ExpenseCategories/IExpenseCategoryRepository.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/IExpenseCategoryRepository.cs
@@ -1,0 +1,6 @@
+﻿namespace Budget.Application.ExpenseCategories;
+
+public interface IExpenseCategoryRepository
+{
+    Task<List<ExpenseCategorySummaryDto>> GetAllAsync(CancellationToken cancellationToken = default);
+}

--- a/src/apis/budget/Budget.Application/ExpenseCategories/Update/UpdateExpenseCategoryCommand.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/Update/UpdateExpenseCategoryCommand.cs
@@ -1,0 +1,3 @@
+﻿namespace Budget.Application.ExpenseCategories.Update;
+
+public sealed record UpdateExpenseCategoryCommand(Guid ExpenseCategoryId, Guid UserId, string Name, string Description, string? ParentCategoryId = null) : IRequest<Unit>{ }

--- a/src/apis/budget/Budget.Application/ExpenseCategories/Update/UpdateExpenseCategoryCommandHandler.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/Update/UpdateExpenseCategoryCommandHandler.cs
@@ -1,0 +1,17 @@
+﻿namespace Budget.Application.ExpenseCategories.Update;
+
+public sealed class UpdateExpenseCategoryCommandHandler(IExpenseCategoryDbContext dbContext) : IRequestHandler<UpdateExpenseCategoryCommand, Unit>
+{
+    public async Task<Unit> Handle(UpdateExpenseCategoryCommand request, CancellationToken cancellationToken)
+    {
+        Guid? parentCategoryId = !string.IsNullOrWhiteSpace(request.ParentCategoryId)
+            ? Guid.Parse(request.ParentCategoryId)
+            : null;
+        ExpenseCategory category = new(request.ExpenseCategoryId, request.Name, request.Description, request.UserId, parentCategoryId);
+
+        await dbContext.UpdateExpenseCategoryAsync(category);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/src/apis/budget/Budget.Application/ExpenseCategories/Update/UpdateExpenseCategoryValidator.cs
+++ b/src/apis/budget/Budget.Application/ExpenseCategories/Update/UpdateExpenseCategoryValidator.cs
@@ -1,0 +1,24 @@
+﻿namespace Budget.Application.ExpenseCategories.Update;
+
+public sealed class UpdateExpenseCategoryValidator : AbstractValidator<UpdateExpenseCategoryCommand>
+{
+    public UpdateExpenseCategoryValidator()
+    {
+        RuleFor(x => x.ExpenseCategoryId)
+            .NotEmpty().WithMessage("Expense category id cannot be empty");
+
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("User id cannot be empty");
+
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Name cannot be empty");
+
+        RuleFor(x => x.Description)
+            .NotEmpty().WithMessage("Description cannot be empty");
+
+        RuleFor(x => x.ParentCategoryId)
+            .Must(x => Guid.TryParse(x, out _))
+                .When(x => x.ParentCategoryId is not null)
+                .WithMessage("Invalid parent category id format");
+    }
+}

--- a/src/apis/budget/Budget.Application/Expenses/Create/CreateExpenseCommandHandler.cs
+++ b/src/apis/budget/Budget.Application/Expenses/Create/CreateExpenseCommandHandler.cs
@@ -8,7 +8,7 @@ public sealed class CreateExpenseCommandHandler(IExpenseDbContext dbContext) : I
         Guid categoryId = Guid.Parse(request.CategoryId);
         Expense newExpense = new(Guid.NewGuid(), request.UserId, request.Amount, request.Currency, expenseDate, request.Description, categoryId);
 
-        await dbContext.AddExpense(newExpense);
+        await dbContext.AddExpenseAsync(newExpense);
         await dbContext.SaveChangesAsync(cancellationToken);
 
         return newExpense.Id;

--- a/src/apis/budget/Budget.Application/Expenses/Delete/DeleteExpenseCommandHandler.cs
+++ b/src/apis/budget/Budget.Application/Expenses/Delete/DeleteExpenseCommandHandler.cs
@@ -4,7 +4,7 @@ public sealed class DeleteExpenseCommandHandler(IExpenseDbContext dbContext) : I
 {
     public async Task<Unit> Handle(DeleteExpenseCommand request, CancellationToken cancellationToken)
     {
-        await dbContext.DeleteExpense(request.ExpenseId, request.UserId);
+        await dbContext.DeleteExpenseAsync(request.ExpenseId, request.UserId);
         await dbContext.SaveChangesAsync(cancellationToken);
 
         return Unit.Value;

--- a/src/apis/budget/Budget.Application/Expenses/IExpenseDbContext.cs
+++ b/src/apis/budget/Budget.Application/Expenses/IExpenseDbContext.cs
@@ -2,8 +2,8 @@
 
 public interface IExpenseDbContext
 {
-    Task AddExpense(Expense expense);
-    Task UpdateExpense(Expense expense);
-    Task DeleteExpense(Guid expenseId, Guid userId);
+    Task AddExpenseAsync(Expense expense);
+    Task UpdateExpenseAsync(Expense expense);
+    Task DeleteExpenseAsync(Guid expenseId, Guid userId);
     Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/apis/budget/Budget.Application/Expenses/Update/UpdateExpenseCommandHandler.cs
+++ b/src/apis/budget/Budget.Application/Expenses/Update/UpdateExpenseCommandHandler.cs
@@ -8,7 +8,7 @@ public class UpdateExpenseCommandHandler(IExpenseDbContext dbContext) : IRequest
         Guid categoryId = Guid.Parse(request.CategoryId);
         Expense expense = new(request.ExpenseId, request.UserId, request.Amount, request.Currency, expenseDate, request.Description, categoryId);
 
-        await dbContext.UpdateExpense(expense);
+        await dbContext.UpdateExpenseAsync(expense);
         await dbContext.SaveChangesAsync(cancellationToken);
 
         return Unit.Value;

--- a/src/apis/budget/Budget.Application/GlobalUsings.cs
+++ b/src/apis/budget/Budget.Application/GlobalUsings.cs
@@ -1,4 +1,4 @@
-﻿global using Budget.Application.Abstractions;
+﻿global using Budget.Application.ExpenseCategories.GetAll;
 global using Budget.Application.Expenses.GetAll;
 global using Budget.Application.Expenses.GetById;
 global using Budget.Domain.Expenses;

--- a/src/apis/budget/Budget.Application/GlobalUsings.cs
+++ b/src/apis/budget/Budget.Application/GlobalUsings.cs
@@ -1,4 +1,5 @@
 ﻿global using Budget.Application.ExpenseCategories.GetAll;
+global using Budget.Application.ExpenseCategories.GetById;
 global using Budget.Application.Expenses.GetAll;
 global using Budget.Application.Expenses.GetById;
 global using Budget.Domain.Expenses;

--- a/src/apis/budget/Budget.Domain/Expenses/ExpenseCategory.cs
+++ b/src/apis/budget/Budget.Domain/Expenses/ExpenseCategory.cs
@@ -53,6 +53,14 @@ public sealed class ExpenseCategory : Entity
         Description = description;
     }
 
+    public void SetParentCategoryId(Guid? parentCategoryId = null)
+    {
+        if (parentCategoryId is not null && parentCategoryId == Guid.Empty)
+            throw new ExpenseException("Invalid parent category id");
+
+        ParentCategoryId = parentCategoryId;
+    }
+
     public void AddSubCategory(ExpenseCategory category)
     {
         if (ParentCategory is not null)

--- a/src/apis/budget/Budget.Domain/Expenses/ExpenseCategory.cs
+++ b/src/apis/budget/Budget.Domain/Expenses/ExpenseCategory.cs
@@ -15,7 +15,7 @@ public sealed class ExpenseCategory : Entity
         SetId(id);
         SetName(name);
         SetDescription(description);
-        ParentCategoryId = parentCategoryId;
+        SetParentCategoryId(parentCategoryId);
         CreatedBy = createdBy;
         ChildCategories = [];
     }
@@ -24,7 +24,7 @@ public sealed class ExpenseCategory : Entity
     {
         SetName(name);
         SetDescription(description);
-        ParentCategoryId = parentCategoryId;
+        SetParentCategoryId(parentCategoryId);
         UpdatedAt = DateTime.UtcNow;
         UpdatedBy = updatedBy;
     }
@@ -62,16 +62,5 @@ public sealed class ExpenseCategory : Entity
             throw new ExpenseException("Cannot set parent to self");
 
         ParentCategoryId = parentCategoryId;
-    }
-
-    public void AddSubCategory(ExpenseCategory category)
-    {
-        if (ParentCategory is not null)
-            throw new ExpenseException("Cannot add to a sub category");
-
-        if (ChildCategories.Any(x => x.Id == category.Id))
-            throw new ExpenseException("Sub category already exist");
-
-        ChildCategories.Add(category);
     }
 }

--- a/src/apis/budget/Budget.Domain/Expenses/ExpenseCategory.cs
+++ b/src/apis/budget/Budget.Domain/Expenses/ExpenseCategory.cs
@@ -10,11 +10,11 @@ public sealed class ExpenseCategory : Entity
     // Navigation Property
     public ICollection<ExpenseCategory> ChildCategories { get; private set; }
 
-    public ExpenseCategory(string name, string description, Guid createdBy, Guid? parentCategoryId = null)
+    public ExpenseCategory(Guid id, string name, string description, Guid createdBy, Guid? parentCategoryId = null)
     {
-        Id = Guid.NewGuid();
-        Name = name;
-        Description = description;
+        SetId(id);
+        SetName(name);
+        SetDescription(description);
         ParentCategoryId = parentCategoryId;
         CreatedBy = createdBy;
         ChildCategories = [];
@@ -22,10 +22,45 @@ public sealed class ExpenseCategory : Entity
 
     public void Update(string name, string description, Guid updatedBy, Guid? parentCategoryId = null)
     {
-        Name = name;
-        Description = description;
+        SetName(name);
+        SetDescription(description);
         ParentCategoryId = parentCategoryId;
         UpdatedAt = DateTime.UtcNow;
         UpdatedBy = updatedBy;
+    }
+
+    public void SetId(Guid id)
+    {
+        if (id == Guid.Empty)
+            throw new ExpenseException("Invalid expense category id");
+
+        Id = id;
+    }
+
+    public void SetName(string name)
+    {
+        if (string.IsNullOrEmpty(name) || string.IsNullOrWhiteSpace(name))
+            throw new ExpenseException("Name cannot be empty");
+
+        Name = name;
+    }
+
+    public void SetDescription(string description)
+    {
+        if (string.IsNullOrEmpty(description) || string.IsNullOrWhiteSpace(description))
+            throw new ExpenseException("Description cannot be empty");
+
+        Description = description;
+    }
+
+    public void AddSubCategory(ExpenseCategory category)
+    {
+        if (ParentCategory is not null)
+            throw new ExpenseException("Cannot add to a sub category");
+
+        if (ChildCategories.Any(x => x.Id == category.Id))
+            throw new ExpenseException("Sub category already exist");
+
+        ChildCategories.Add(category);
     }
 }

--- a/src/apis/budget/Budget.Domain/Expenses/ExpenseCategory.cs
+++ b/src/apis/budget/Budget.Domain/Expenses/ExpenseCategory.cs
@@ -58,6 +58,9 @@ public sealed class ExpenseCategory : Entity
         if (parentCategoryId is not null && parentCategoryId == Guid.Empty)
             throw new ExpenseException("Invalid parent category id");
 
+        if (parentCategoryId is not null && parentCategoryId == Id)
+            throw new ExpenseException("Cannot set parent to self");
+
         ParentCategoryId = parentCategoryId;
     }
 

--- a/src/apis/budget/Budget.Infrastructure/Database/BudgetDbContext.cs
+++ b/src/apis/budget/Budget.Infrastructure/Database/BudgetDbContext.cs
@@ -13,7 +13,7 @@ public sealed class BudgetDbContext(DbContextOptions<BudgetDbContext> options) :
         builder.ApplyConfigurationsFromAssembly(typeof(BudgetDbContext).Assembly);
     }
 
-    public async Task AddExpense(Expense expense) 
+    public async Task AddExpenseAsync(Expense expense) 
     {
         ExpenseCategory? category = await ExpenseCategories.FirstOrDefaultAsync(x => x.Id == expense.CategoryId) 
             ?? throw new ExpenseException($"Invalid category id: {expense.CategoryId}");
@@ -21,7 +21,7 @@ public sealed class BudgetDbContext(DbContextOptions<BudgetDbContext> options) :
         Expenses.Add(expense);
     }
 
-    public async Task UpdateExpense(Expense expense)
+    public async Task UpdateExpenseAsync(Expense expense)
     {
         Expense? dbExpense = await Expenses.FirstOrDefaultAsync(x => x.Id == expense.Id && x.UserId == expense.UserId)
             ?? throw new ExpenseException($"Invalid expense id: {expense.Id}", HttpStatusCode.NotFound);
@@ -33,7 +33,7 @@ public sealed class BudgetDbContext(DbContextOptions<BudgetDbContext> options) :
         Expenses.Update(dbExpense);
     }
 
-    public async Task DeleteExpense(Guid expenseId, Guid userId)
+    public async Task DeleteExpenseAsync(Guid expenseId, Guid userId)
     {
         Expense? dbExpense = await Expenses.FirstOrDefaultAsync(x => x.Id == expenseId && x.UserId == userId)
             ?? throw new ExpenseException($"Invalid expense id: {expenseId}", HttpStatusCode.NotFound);

--- a/src/apis/budget/Budget.Infrastructure/Database/BudgetDbContext.cs
+++ b/src/apis/budget/Budget.Infrastructure/Database/BudgetDbContext.cs
@@ -70,7 +70,7 @@ public sealed class BudgetDbContext(DbContextOptions<BudgetDbContext> options) :
     {
         // Target category does not exist
         ExpenseCategory? dbCategory = await ExpenseCategories.FirstOrDefaultAsync(x => x.Id == expenseCategory.Id)
-            ?? throw new ExpenseException($"Invalid expense category id: {expenseCategory.Id}");
+            ?? throw new ExpenseException($"Invalid expense category id: {expenseCategory.Id}", HttpStatusCode.NotFound);
 
         // Different category with new updated name already exist
         if (await ExpenseCategories.AnyAsync(x => x.Id != expenseCategory.Id &&  x.Name.ToLower() == expenseCategory.Name.ToLower()))
@@ -86,6 +86,15 @@ public sealed class BudgetDbContext(DbContextOptions<BudgetDbContext> options) :
         dbCategory.Update(expenseCategory.Name, expenseCategory.Description, expenseCategory.CreatedBy, expenseCategory.ParentCategoryId);
         ExpenseCategories.Update(dbCategory);
     }
+
+    public async Task DeleteExpenseCategoryAsync(Guid expenseCategoryId)
+    {
+        ExpenseCategory? dbCategory = await ExpenseCategories.FirstOrDefaultAsync(x => x.Id == expenseCategoryId)
+            ?? throw new ExpenseException($"Invalid expense category id: {expenseCategoryId}", HttpStatusCode.NotFound);
+
+        ExpenseCategories.Remove(dbCategory);
+    }
+
 
     async Task IExpenseCategoryDbContext.SaveChangesAsync(CancellationToken cancellationToken)
     {

--- a/src/apis/budget/Budget.Infrastructure/ExpenseCategories/ExpenseCategoryRepository.cs
+++ b/src/apis/budget/Budget.Infrastructure/ExpenseCategories/ExpenseCategoryRepository.cs
@@ -1,0 +1,11 @@
+﻿namespace Budget.Infrastructure.ExpenseCategories;
+
+public sealed class ExpenseCategoryRepository(BudgetDbContext dbContext) : IExpenseCategoryRepository
+{
+    public async Task<List<ExpenseCategorySummaryDto>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await dbContext.ExpensesCategories
+            .Select(x => new ExpenseCategorySummaryDto(x.Id, x.Name, x.Description, x.ParentCategoryId))
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/src/apis/budget/Budget.Infrastructure/ExpenseCategories/ExpenseCategoryRepository.cs
+++ b/src/apis/budget/Budget.Infrastructure/ExpenseCategories/ExpenseCategoryRepository.cs
@@ -3,13 +3,13 @@
 public sealed class ExpenseCategoryRepository(BudgetDbContext dbContext) : IExpenseCategoryRepository
 {
     public async Task<List<ExpenseCategorySummaryDto>> GetAllAsync(CancellationToken cancellationToken = default)
-        => await dbContext.ExpensesCategories
+        => await dbContext.ExpenseCategories
         .Select(x => new ExpenseCategorySummaryDto(x.Id, x.Name, x.Description, x.ParentCategoryId))
         .ToListAsync(cancellationToken);
 
     public async Task<ExpenseCategoryDetailDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
-        return await dbContext.ExpensesCategories
+        return await dbContext.ExpenseCategories
             .Where(x => x.Id == id)
             .Select(x => new ExpenseCategoryDetailDto(
                 x.Id,

--- a/src/apis/budget/Budget.Infrastructure/ExpenseCategories/ExpenseCategoryRepository.cs
+++ b/src/apis/budget/Budget.Infrastructure/ExpenseCategories/ExpenseCategoryRepository.cs
@@ -3,9 +3,24 @@
 public sealed class ExpenseCategoryRepository(BudgetDbContext dbContext) : IExpenseCategoryRepository
 {
     public async Task<List<ExpenseCategorySummaryDto>> GetAllAsync(CancellationToken cancellationToken = default)
+        => await dbContext.ExpensesCategories
+        .Select(x => new ExpenseCategorySummaryDto(x.Id, x.Name, x.Description, x.ParentCategoryId))
+        .ToListAsync(cancellationToken);
+
+    public async Task<ExpenseCategoryDetailDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
         return await dbContext.ExpensesCategories
-            .Select(x => new ExpenseCategorySummaryDto(x.Id, x.Name, x.Description, x.ParentCategoryId))
-            .ToListAsync(cancellationToken);
+            .Where(x => x.Id == id)
+            .Select(x => new ExpenseCategoryDetailDto(
+                x.Id,
+                x.Name,
+                x.Description,
+                x.CreatedBy,
+                x.CreatedAt,
+                x.UpdatedBy,
+                x.UpdatedAt,
+                x.ParentCategoryId,
+                (x.ParentCategory != null) ? x.ParentCategory.Name : null))
+            .FirstOrDefaultAsync(cancellationToken);
     }
 }

--- a/src/apis/budget/Budget.Infrastructure/ExpenseCategories/ExpenseCategoryTypeConfiguration.cs
+++ b/src/apis/budget/Budget.Infrastructure/ExpenseCategories/ExpenseCategoryTypeConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace Budget.Infrastructure.Expenses;
+﻿namespace Budget.Infrastructure.ExpenseCategories;
 
 internal sealed class ExpenseCategoryTypeConfiguration : IEntityTypeConfiguration<ExpenseCategory>
 {

--- a/src/apis/budget/Budget.Infrastructure/GlobalUsings.cs
+++ b/src/apis/budget/Budget.Infrastructure/GlobalUsings.cs
@@ -1,4 +1,6 @@
 ﻿global using Budget.Application.Abstractions;
+global using Budget.Application.ExpenseCategories;
+global using Budget.Application.ExpenseCategories.GetAll;
 global using Budget.Application.Expenses;
 global using Budget.Application.Expenses.GetAll;
 global using Budget.Application.Expenses.GetById;

--- a/src/apis/budget/Budget.Infrastructure/GlobalUsings.cs
+++ b/src/apis/budget/Budget.Infrastructure/GlobalUsings.cs
@@ -1,6 +1,7 @@
 ﻿global using Budget.Application.Abstractions;
 global using Budget.Application.ExpenseCategories;
 global using Budget.Application.ExpenseCategories.GetAll;
+global using Budget.Application.ExpenseCategories.GetById;
 global using Budget.Application.Expenses;
 global using Budget.Application.Expenses.GetAll;
 global using Budget.Application.Expenses.GetById;

--- a/src/aspire/API.MigrationService/SeedData.cs
+++ b/src/aspire/API.MigrationService/SeedData.cs
@@ -29,10 +29,10 @@ public static class SeedData
 
     public static async Task SeedExpensesAsync(BudgetDbContext dbContext)
     {
-        ExpenseCategory foodCategory = new("Food", "Food Categories", UserId);
-        ExpenseCategory transportCategory = new("Transportation", "Transportation Category", UserId);
-        ExpenseCategory apparelCategory = new("Apparel", "Apparel Category", UserId);
-        dbContext.ExpensesCategories.AddRange([foodCategory, transportCategory, apparelCategory]);
+        ExpenseCategory foodCategory = new(Guid.NewGuid(), "Food", "Food Categories", UserId);
+        ExpenseCategory transportCategory = new(Guid.NewGuid(), "Transportation", "Transportation Category", UserId);
+        ExpenseCategory apparelCategory = new(Guid.NewGuid(), "Apparel", "Apparel Category", UserId);
+        dbContext.ExpenseCategories.AddRange([foodCategory, transportCategory, apparelCategory]);
 
         Expense foodExpense = new(Guid.NewGuid(), UserId, 500, "PHP", DateTime.Today.ToUniversalTime(), "Lunch", foodCategory.Id);
         Expense transportExpense = new(Guid.NewGuid(), UserId, 250, "PHP", DateTime.Today.ToUniversalTime(), "Grab Taxi", transportCategory.Id);

--- a/src/aspire/API.MigrationService/Worker.cs
+++ b/src/aspire/API.MigrationService/Worker.cs
@@ -26,7 +26,7 @@ public class Worker(IServiceProvider serviceProvider, IHostApplicationLifetime h
         }
         catch (Exception ex) 
         {
-            activity?.RecordException(ex);
+            activity?.AddException(ex);
             throw;
         }
 

--- a/src/tests/budget/Budget.UnitTests/Budget.UnitTests.csproj
+++ b/src/tests/budget/Budget.UnitTests/Budget.UnitTests.csproj
@@ -33,4 +33,10 @@
     <ProjectReference Include="..\..\..\apis\budget\Budget.Infrastructure\Budget.Infrastructure.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="ExpenseCategories\Commands\" />
+    <Folder Include="ExpenseCategories\Domain\" />
+    <Folder Include="ExpenseCategories\Validators\" />
+  </ItemGroup>
+
 </Project>

--- a/src/tests/budget/Budget.UnitTests/Budget.UnitTests.csproj
+++ b/src/tests/budget/Budget.UnitTests/Budget.UnitTests.csproj
@@ -35,7 +35,6 @@
 
   <ItemGroup>
     <Folder Include="ExpenseCategories\Commands\" />
-    <Folder Include="ExpenseCategories\Domain\" />
     <Folder Include="ExpenseCategories\Validators\" />
   </ItemGroup>
 

--- a/src/tests/budget/Budget.UnitTests/Budget.UnitTests.csproj
+++ b/src/tests/budget/Budget.UnitTests/Budget.UnitTests.csproj
@@ -33,9 +33,4 @@
     <ProjectReference Include="..\..\..\apis\budget\Budget.Infrastructure\Budget.Infrastructure.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="ExpenseCategories\Commands\" />
-    <Folder Include="ExpenseCategories\Validators\" />
-  </ItemGroup>
-
 </Project>

--- a/src/tests/budget/Budget.UnitTests/ExpenseCategories/Commands/CreateExpenseCategoryCommandHandlerUnitTests.cs
+++ b/src/tests/budget/Budget.UnitTests/ExpenseCategories/Commands/CreateExpenseCategoryCommandHandlerUnitTests.cs
@@ -1,0 +1,43 @@
+﻿namespace Budget.UnitTests.ExpenseCategories.Commands;
+
+public sealed class CreateExpenseCategoryCommandHandlerUnitTests
+{
+    private readonly Mock<IExpenseCategoryDbContext> _dbContext = new();
+    private readonly CreateExpenseCategoryCommandHandler _handler;
+
+    public CreateExpenseCategoryCommandHandlerUnitTests()
+    {
+        _handler = new(_dbContext.Object);
+    }
+
+    [Fact]
+    public async Task Handle_AddExpenseCategoryFails_ThrowsExpenseException()
+    {
+        // Arrange
+        CreateExpenseCategoryCommand command = new(Guid.NewGuid(), "Already Exist", "Already EXist");
+        _dbContext.Setup(x => x.AddExpenseCategoryAsync(It.IsAny<ExpenseCategory>()))
+            .ThrowsAsync(new ExpenseException("Name already exist"));
+
+        // Act && Assert
+        await Assert.ThrowsAsync<ExpenseException>(() => _handler.Handle(command, CancellationToken.None));
+        _dbContext.Verify(x => x.AddExpenseCategoryAsync(It.IsAny<ExpenseCategory>()), Times.Once());
+        _dbContext.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Never());
+    }
+
+    [Fact]
+    public async Task Handle_AddExpenseCategorySucceed_SaveChangesAndReturnNewId()
+    {
+        // Arrange
+        CreateExpenseCategoryCommand command = new(Guid.NewGuid(), "Test Category", "Test Category Description");
+        _dbContext.Setup(x => x.AddExpenseCategoryAsync(It.IsAny<ExpenseCategory>()));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.IsType<Guid>(result);
+        Assert.NotEqual(Guid.Empty, result);
+        _dbContext.Verify(x => x.AddExpenseCategoryAsync(It.IsAny<ExpenseCategory>()), Times.Once());
+        _dbContext.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Once());
+    }
+}

--- a/src/tests/budget/Budget.UnitTests/ExpenseCategories/Commands/DeleteExpenseCategoryCommandHandlerUnitTests.cs
+++ b/src/tests/budget/Budget.UnitTests/ExpenseCategories/Commands/DeleteExpenseCategoryCommandHandlerUnitTests.cs
@@ -1,0 +1,44 @@
+﻿namespace Budget.UnitTests.ExpenseCategories.Commands;
+
+public sealed class DeleteExpenseCategoryCommandHandlerUnitTests
+{
+    private readonly Mock<IExpenseCategoryDbContext> _dbContext = new();
+    private readonly DeleteExpenseCategoryCommandHandler _handler;
+
+    public DeleteExpenseCategoryCommandHandlerUnitTests()
+    {
+        _handler = new(_dbContext.Object);
+    }
+
+    [Fact]
+    public async Task Handle_DeleteExpenseFails_ThrowsExpenseException()
+    {
+        // Arrange
+        DeleteExpenseCategoryCommand command = new(Guid.NewGuid());
+        _dbContext.Setup(x => x.DeleteExpenseCategoryAsync(It.IsAny<Guid>()))
+            .ThrowsAsync(new ExpenseException("Invalid expense category"));
+
+        // Act
+        await Assert.ThrowsAsync<ExpenseException>(() => _handler.Handle(command, CancellationToken.None));
+
+        // Assert
+        _dbContext.Verify(x => x.DeleteExpenseCategoryAsync(It.IsAny<Guid>()), Times.Once());
+        _dbContext.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Never());
+    }
+
+    [Fact]
+    public async Task Handle_DeleteExpenseSucceed_SaveChanges()
+    {
+        // Arrange
+        DeleteExpenseCategoryCommand command = new(Guid.NewGuid());
+        _dbContext.Setup(x => x.DeleteExpenseCategoryAsync(It.IsAny<Guid>()));
+        _dbContext.Setup(x => x.SaveChangesAsync(CancellationToken.None));
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _dbContext.Verify(x => x.DeleteExpenseCategoryAsync(It.IsAny<Guid>()), Times.Once());
+        _dbContext.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Once());
+    }
+}

--- a/src/tests/budget/Budget.UnitTests/ExpenseCategories/Commands/UpdateExpenseCategoryCommandHandleUnitTests.cs
+++ b/src/tests/budget/Budget.UnitTests/ExpenseCategories/Commands/UpdateExpenseCategoryCommandHandleUnitTests.cs
@@ -1,0 +1,44 @@
+﻿namespace Budget.UnitTests.ExpenseCategories.Commands;
+
+public sealed class UpdateExpenseCategoryCommandHandleUnitTests
+{
+    private readonly Mock<IExpenseCategoryDbContext> _dbContext = new();
+    private readonly UpdateExpenseCategoryCommandHandler _handler;
+
+    public UpdateExpenseCategoryCommandHandleUnitTests()
+    {
+        _handler = new(_dbContext.Object);
+    }
+
+    [Fact]
+    public async Task Handle_UpdateExpenseCategoryFails_ThrowsExpenseException()
+    {
+        // Arrange
+        UpdateExpenseCategoryCommand command = new(Guid.NewGuid(), Guid.NewGuid(), "Test Category", "Test Category Description");
+        _dbContext.Setup(x => x.UpdateExpenseCategoryAsync(It.IsAny<ExpenseCategory>()))
+            .ThrowsAsync(new ExpenseException("Invalid expense category name"));
+
+        // Act
+        await Assert.ThrowsAsync<ExpenseException>(() => _handler.Handle(command, CancellationToken.None));
+
+        // Assert
+        _dbContext.Verify(x => x.UpdateExpenseCategoryAsync(It.IsAny<ExpenseCategory>()), Times.Once());
+        _dbContext.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Never());
+    }
+
+    [Fact]
+    public async Task Handle_UpdateExpenseCategorySucceed_SaveChanges()
+    {
+        // Arrange
+        UpdateExpenseCategoryCommand command = new(Guid.NewGuid(), Guid.NewGuid(), "Test Category", "Test Category Description");
+        _dbContext.Setup(x => x.UpdateExpenseCategoryAsync(It.IsAny<ExpenseCategory>()));
+        _dbContext.Setup(x => x.SaveChangesAsync(CancellationToken.None));
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _dbContext.Verify(x => x.UpdateExpenseCategoryAsync(It.IsAny<ExpenseCategory>()), Times.Once());
+        _dbContext.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Once());
+    }
+}

--- a/src/tests/budget/Budget.UnitTests/ExpenseCategories/Domain/ExpenseCategoryUnitTests.cs
+++ b/src/tests/budget/Budget.UnitTests/ExpenseCategories/Domain/ExpenseCategoryUnitTests.cs
@@ -1,0 +1,46 @@
+﻿namespace Budget.UnitTests.ExpenseCategories.Domain;
+
+public sealed class ExpenseCategoryUnitTests
+{
+    [Fact]
+    public void ExpenseCategoryId_IsEmptyGuid_ThrowsExpenseException()
+    {
+        // Arrange, Act, && Assert
+        Assert.Throws<ExpenseException>(() => new ExpenseCategory(Guid.Empty, "Test Category", "Test Category Description", Guid.NewGuid()));
+    }
+
+    [Theory]
+    [InlineData(null!)]
+    [InlineData(" ")]
+    public void Name_IsEmptyOrWhitespace_ThrowsExpenseException(string? name)
+    {
+        // Arrange, Act, && Assert
+        Assert.Throws<ExpenseException>(() => new ExpenseCategory(Guid.NewGuid(), name!, "Test Category Description", Guid.NewGuid()));
+    }
+
+    [Theory]
+    [InlineData(null!)]
+    [InlineData(" ")]
+    public void Description_IsEmptyOrWhitespace_ThrowsExpenseException(string? description)
+    {
+        // Arrange, Act, && Assert
+        Assert.Throws<ExpenseException>(() => new ExpenseCategory(Guid.NewGuid(), "Test Category", description!, Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void ParentCategoryId_IsEmptyGuid_ThrowsExpenseException()
+    {
+        // Arrange, Act, && Assert
+        Assert.Throws<ExpenseException>(() => new ExpenseCategory(Guid.NewGuid(), "Test Category", "Test Category Description", Guid.NewGuid(), Guid.Empty));
+    }
+
+    [Fact]
+    public void ParentCategoryId_IsTheSameWithSelfId_ThrowsExpenseException()
+    {
+        // Arrange
+        Guid id = Guid.NewGuid();
+
+        // Act, && Assert
+        Assert.Throws<ExpenseException>(() => new ExpenseCategory(id, "Test Category", "Test Category Description", Guid.NewGuid(), id));
+    }
+}

--- a/src/tests/budget/Budget.UnitTests/ExpenseCategories/Queries/GetExpenseCategoriesQueryHandlerUnitTests.cs
+++ b/src/tests/budget/Budget.UnitTests/ExpenseCategories/Queries/GetExpenseCategoriesQueryHandlerUnitTests.cs
@@ -1,0 +1,50 @@
+﻿namespace Budget.UnitTests.ExpenseCategories.Queries;
+
+public sealed class GetExpenseCategoriesQueryHandlerUnitTests
+{
+    private readonly Mock<IExpenseCategoryRepository> _repository = new();
+    private readonly GetExpenseCategoriesQueryHandler _handler;
+
+    public GetExpenseCategoriesQueryHandlerUnitTests()
+    {
+        _handler = new(_repository.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ExpenseCategoriesDoesNotExist_ReturnEmptySet()
+    {
+        // Arrange
+        GetExpenseCategoriesQuery query = new();
+        _repository.Setup(x => x.GetAllAsync(CancellationToken.None))
+            .ReturnsAsync([]);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        _repository.Verify(x => x.GetAllAsync(CancellationToken.None), Times.Once());
+        Assert.IsType<List<ExpenseCategorySummaryDto>>(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task Handle_ExpenseCategoriesExist_ReturnExpenseCategorySummaryDtos()
+    {
+        // Arrange
+        GetExpenseCategoriesQuery query = new();
+        _repository.Setup(x => x.GetAllAsync(CancellationToken.None))
+            .ReturnsAsync([
+                new ExpenseCategorySummaryDto(Guid.NewGuid(), "Category #1", "Category #1 Description"),
+                new ExpenseCategorySummaryDto(Guid.NewGuid(), "Category #2", "Category #2 Description"),
+                new ExpenseCategorySummaryDto(Guid.NewGuid(), "Category #3", "Category #3 Description")]);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        _repository.Verify(x => x.GetAllAsync(CancellationToken.None), Times.Once());
+        Assert.IsType<List<ExpenseCategorySummaryDto>>(result);
+        Assert.NotEmpty(result);
+        Assert.Equal(3, result.Count);
+    }
+}

--- a/src/tests/budget/Budget.UnitTests/ExpenseCategories/Queries/GetExpenseCategoryByIdQueryHandlerUnitTests.cs
+++ b/src/tests/budget/Budget.UnitTests/ExpenseCategories/Queries/GetExpenseCategoryByIdQueryHandlerUnitTests.cs
@@ -1,0 +1,41 @@
+﻿namespace Budget.UnitTests.ExpenseCategories.Queries;
+
+public sealed class GetExpenseCategoryByIdQueryHandlerUnitTests
+{
+    private readonly Mock<IExpenseCategoryRepository> _repository = new();
+    private readonly GetExpenseCategoryByIdQueryHandler _handler;
+
+    public GetExpenseCategoryByIdQueryHandlerUnitTests()
+    {
+        _handler = new(_repository.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ExpenseCategoryDoesNotExist_ThrowsNotFoundException()
+    {
+        // Arrange
+        GetExpenseCategoryByIdQuery query = new(Guid.NewGuid());
+        _repository.Setup(x => x.GetByIdAsync(It.IsAny<Guid>(), CancellationToken.None))
+            .ReturnsAsync((ExpenseCategoryDetailDto)null!);
+
+        // Act && Assert
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(query, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_ExpenseCategoryExist_ReturnExpenseCategoryDetailDto()
+    {
+        // Arrange
+        ExpenseCategoryDetailDto expenseCategory = new(Guid.NewGuid(), "Test Category", "Test Category Description", Guid.NewGuid(), DateTime.UtcNow);
+        GetExpenseCategoryByIdQuery query = new(expenseCategory.Id);
+        _repository.Setup(x => x.GetByIdAsync(It.IsAny<Guid>(), CancellationToken.None))
+            .ReturnsAsync(expenseCategory);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        _repository.Verify(x => x.GetByIdAsync(It.IsAny<Guid>(), CancellationToken.None), Times.Once());
+        Assert.IsType<ExpenseCategoryDetailDto>(result);
+    }
+}

--- a/src/tests/budget/Budget.UnitTests/ExpenseCategories/Validators/CreateExpenseCategoryValidatorUnitTests.cs
+++ b/src/tests/budget/Budget.UnitTests/ExpenseCategories/Validators/CreateExpenseCategoryValidatorUnitTests.cs
@@ -1,0 +1,64 @@
+﻿using FluentValidation;
+
+namespace Budget.UnitTests.ExpenseCategories.Validators;
+
+public sealed class CreateExpenseCategoryValidatorUnitTests
+{
+    public readonly CreateExpenseCategoryValidator _validator = new();
+
+    [Fact]
+    public async Task UserId_IsEmpty_ReturnsAnError()
+    {
+        // Arrange
+        CreateExpenseCategoryCommand command = new(Guid.Empty, "Test Category", "Test Category Description");
+
+        // Act
+        var result = await _validator.ValidateAsync(command);
+
+        // Assert
+        Assert.NotEmpty(result.Errors);
+        Assert.True(result.Errors?.Any(x => x.PropertyName == nameof(CreateExpenseCategoryCommand.UserId)));
+    }
+
+    [Fact]
+    public async Task Name_IsEmpty_ReturnsAnError()
+    {
+        // Arrange
+        CreateExpenseCategoryCommand command = new(Guid.NewGuid(), "", "Test Category Description");
+
+        // Act
+        var result = await _validator.ValidateAsync(command);
+
+        // Assert
+        Assert.NotEmpty(result.Errors);
+        Assert.True(result.Errors?.Any(x => x.PropertyName == nameof(CreateExpenseCategoryCommand.Name)));
+    }
+
+    [Fact]
+    public async Task Description_IsEmpty_ReturnsAnError()
+    {
+        // Arrange
+        CreateExpenseCategoryCommand command = new(Guid.NewGuid(), "Test Category", "");
+
+        // Act
+        var result = await _validator.ValidateAsync(command);
+
+        // Assert
+        Assert.NotEmpty(result.Errors);
+        Assert.True(result.Errors?.Any(x => x.PropertyName == nameof(CreateExpenseCategoryCommand.Description)));
+    }
+
+    [Fact]
+    public async Task ParentCategoryId_IsInvalidFormat_ReturnsAnError()
+    {
+        // Arrange
+        CreateExpenseCategoryCommand command = new(Guid.NewGuid(), "Test Category", "Test Category Description", "111");
+
+        // Act
+        var result = await _validator.ValidateAsync(command);
+
+        // Assert
+        Assert.NotEmpty(result.Errors);
+        Assert.True(result.Errors?.Any(x => x.PropertyName == nameof(CreateExpenseCategoryCommand.ParentCategoryId)));
+    }
+}

--- a/src/tests/budget/Budget.UnitTests/ExpenseCategories/Validators/DeleteExpenseCategoryValidatorUnitTests.cs
+++ b/src/tests/budget/Budget.UnitTests/ExpenseCategories/Validators/DeleteExpenseCategoryValidatorUnitTests.cs
@@ -1,0 +1,20 @@
+﻿namespace Budget.UnitTests.ExpenseCategories.Validators;
+
+public sealed class DeleteExpenseCategoryValidatorUnitTests
+{
+    private readonly DeleteExpenseCategoryValidator _validator = new();
+
+    [Fact]
+    public async Task ExpenseCategoryId_IsEmpty_ReturnsAnError()
+    {
+        // Arrange
+        DeleteExpenseCategoryCommand command = new(Guid.Empty);
+
+        // Act
+        var result = await _validator.ValidateAsync(command);
+
+        // Assert
+        Assert.NotEmpty(result.Errors);
+        Assert.True(result.Errors?.Any(x => x.PropertyName == nameof(DeleteExpenseCategoryCommand.Id)));
+    }
+}

--- a/src/tests/budget/Budget.UnitTests/ExpenseCategories/Validators/UpdateExpenseCategoryValidatorUnitTests.cs
+++ b/src/tests/budget/Budget.UnitTests/ExpenseCategories/Validators/UpdateExpenseCategoryValidatorUnitTests.cs
@@ -1,0 +1,76 @@
+﻿namespace Budget.UnitTests.ExpenseCategories.Validators;
+
+public sealed class UpdateExpenseCategoryValidatorUnitTests
+{
+    private readonly UpdateExpenseCategoryValidator _validator = new();
+
+    [Fact]
+    public async Task ExpenseCategoryId_IsEmpty_ReturnsAnError()
+    {
+        // Arrange
+        UpdateExpenseCategoryCommand command = new(Guid.Empty, Guid.NewGuid(), "Test Category", "Test Category Description");
+
+        // Act
+        var result = await _validator.ValidateAsync(command);
+
+        // Assert
+        Assert.NotEmpty(result.Errors);
+        Assert.True(result.Errors?.Any(x => x.PropertyName == nameof(UpdateExpenseCategoryCommand.ExpenseCategoryId)));
+    }
+
+    [Fact]
+    public async Task UserId_IsEmpty_ReturnsAnError()
+    {
+        // Arrange
+        UpdateExpenseCategoryCommand command = new(Guid.NewGuid(), Guid.Empty, "Test Category", "Test Category Description");
+
+        // Act
+        var result = await _validator.ValidateAsync(command);
+
+        // Assert
+        Assert.NotEmpty(result.Errors);
+        Assert.True(result.Errors?.Any(x => x.PropertyName == nameof(UpdateExpenseCategoryCommand.UserId)));
+    }
+
+    [Fact]
+    public async Task Name_IsEmpty_ReturnsAnError()
+    {
+        // Arrange
+        UpdateExpenseCategoryCommand command = new(Guid.NewGuid(), Guid.NewGuid(), "", "Test Category Description");
+
+        // Act
+        var result = await _validator.ValidateAsync(command);
+
+        // Assert
+        Assert.NotEmpty(result.Errors);
+        Assert.True(result.Errors?.Any(x => x.PropertyName == nameof(UpdateExpenseCategoryCommand.Name)));
+    }
+
+    [Fact]
+    public async Task Description_IsEmpty_ReturnsAnError()
+    {
+        // Arrange
+        UpdateExpenseCategoryCommand command = new(Guid.NewGuid(), Guid.NewGuid(), "Test Category", "");
+
+        // Act
+        var result = await _validator.ValidateAsync(command);
+
+        // Assert
+        Assert.NotEmpty(result.Errors);
+        Assert.True(result.Errors?.Any(x => x.PropertyName == nameof(UpdateExpenseCategoryCommand.Description)));
+    }
+
+    [Fact]
+    public async Task ParentCategoryId_IsInvalidFormat_ReturnsAnError()
+    {
+        // Arrange
+        UpdateExpenseCategoryCommand command = new(Guid.NewGuid(), Guid.NewGuid(), "Test Category", "Test Category Description", "111");
+
+        // Act
+        var result = await _validator.ValidateAsync(command);
+
+        // Assert
+        Assert.NotEmpty(result.Errors);
+        Assert.True(result.Errors?.Any(x => x.PropertyName == nameof(UpdateExpenseCategoryCommand.ParentCategoryId)));
+    }
+}

--- a/src/tests/budget/Budget.UnitTests/Expenses/Commands/CreateExpenseCommandHandlerTests.cs
+++ b/src/tests/budget/Budget.UnitTests/Expenses/Commands/CreateExpenseCommandHandlerTests.cs
@@ -15,14 +15,14 @@ public sealed class CreateExpenseCommandHandlerTests
     {
         // Arrange
         CreateExpenseCommand command = new(Guid.NewGuid(), 1000, "PHP", DateTime.UtcNow.ToShortDateString(), "Test Expense", Guid.NewGuid().ToString());
-        _dbContext.Setup(x => x.AddExpense(It.IsAny<Expense>()))
+        _dbContext.Setup(x => x.AddExpenseAsync(It.IsAny<Expense>()))
             .ThrowsAsync(new ExpenseException("Invalid expense category"));
 
         // Act
         await Assert.ThrowsAsync<ExpenseException>(() => _handler.Handle(command, CancellationToken.None));
 
         // Assert
-        _dbContext.Verify(x => x.AddExpense(It.IsAny<Expense>()),Times.Once());
+        _dbContext.Verify(x => x.AddExpenseAsync(It.IsAny<Expense>()),Times.Once());
         _dbContext.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Never());
     }
 
@@ -31,7 +31,7 @@ public sealed class CreateExpenseCommandHandlerTests
     {
         // Arrange
         CreateExpenseCommand command = new(Guid.NewGuid(), 1000, "PHP", DateTime.UtcNow.ToShortDateString(), "Test Expense", Guid.NewGuid().ToString());
-        _dbContext.Setup(x => x.AddExpense(It.IsAny<Expense>()));
+        _dbContext.Setup(x => x.AddExpenseAsync(It.IsAny<Expense>()));
         _dbContext.Setup(x => x.SaveChangesAsync(CancellationToken.None));
 
         // Act
@@ -40,7 +40,7 @@ public sealed class CreateExpenseCommandHandlerTests
         // Assert
         Assert.IsType<Guid>(result);
         Assert.NotEqual(Guid.Empty, result);
-        _dbContext.Verify(x => x.AddExpense(It.IsAny<Expense>()), Times.Once());
+        _dbContext.Verify(x => x.AddExpenseAsync(It.IsAny<Expense>()), Times.Once());
         _dbContext.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Once());        
     }
 }

--- a/src/tests/budget/Budget.UnitTests/Expenses/Commands/CreateExpenseCommandHandlerTests.cs
+++ b/src/tests/budget/Budget.UnitTests/Expenses/Commands/CreateExpenseCommandHandlerTests.cs
@@ -11,7 +11,7 @@ public sealed class CreateExpenseCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ExpenseCategoryDoesNotExist_ThrowsExpenseException()
+    public async Task Handle_AddExpenseFails_ThrowsExpenseException()
     {
         // Arrange
         CreateExpenseCommand command = new(Guid.NewGuid(), 1000, "PHP", DateTime.UtcNow.ToShortDateString(), "Test Expense", Guid.NewGuid().ToString());
@@ -27,7 +27,7 @@ public sealed class CreateExpenseCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ExpenseDataIsValid_ReturnNewExpenseId()
+    public async Task Handle_AddExpenseSucceed_SaveChangesAndReturnNewId()
     {
         // Arrange
         CreateExpenseCommand command = new(Guid.NewGuid(), 1000, "PHP", DateTime.UtcNow.ToShortDateString(), "Test Expense", Guid.NewGuid().ToString());

--- a/src/tests/budget/Budget.UnitTests/Expenses/Commands/DeleteExpenseCommandHandlerUnitTests.cs
+++ b/src/tests/budget/Budget.UnitTests/Expenses/Commands/DeleteExpenseCommandHandlerUnitTests.cs
@@ -11,7 +11,7 @@ public sealed class DeleteExpenseCommandHandlerUnitTests
     }
 
     [Fact]
-    public async Task Handle_ExpenseDoesNotExist_ThrowsExpenseException()
+    public async Task Handle_DeleteExpenseFails_ThrowsExpenseException()
     {
         // Arrange
         DeleteExpenseCommand command = new(Guid.NewGuid(), Guid.NewGuid());
@@ -27,7 +27,7 @@ public sealed class DeleteExpenseCommandHandlerUnitTests
     }
 
     [Fact]
-    public async Task Handle_ExpenseDoesExist_DeleteExpense()
+    public async Task Handle_DeleteExpenseSucceed_SaveChanges()
     {
         // Arrange
         DeleteExpenseCommand command = new(Guid.NewGuid(), Guid.NewGuid());

--- a/src/tests/budget/Budget.UnitTests/Expenses/Commands/DeleteExpenseCommandHandlerUnitTests.cs
+++ b/src/tests/budget/Budget.UnitTests/Expenses/Commands/DeleteExpenseCommandHandlerUnitTests.cs
@@ -15,14 +15,14 @@ public sealed class DeleteExpenseCommandHandlerUnitTests
     {
         // Arrange
         DeleteExpenseCommand command = new(Guid.NewGuid(), Guid.NewGuid());
-        _dbContext.Setup(x => x.DeleteExpense(It.IsAny<Guid>(), It.IsAny<Guid>()))
+        _dbContext.Setup(x => x.DeleteExpenseAsync(It.IsAny<Guid>(), It.IsAny<Guid>()))
             .ThrowsAsync(new ExpenseException("Invalid expense"));
 
         // Act
         await Assert.ThrowsAsync<ExpenseException>(() => _handler.Handle(command, CancellationToken.None));
 
         // Assert
-        _dbContext.Verify(x => x.DeleteExpense(It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Once());
+        _dbContext.Verify(x => x.DeleteExpenseAsync(It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Once());
         _dbContext.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Never());
     }
 
@@ -31,14 +31,14 @@ public sealed class DeleteExpenseCommandHandlerUnitTests
     {
         // Arrange
         DeleteExpenseCommand command = new(Guid.NewGuid(), Guid.NewGuid());
-        _dbContext.Setup(x => x.DeleteExpense(It.IsAny<Guid>(), It.IsAny<Guid>()));
+        _dbContext.Setup(x => x.DeleteExpenseAsync(It.IsAny<Guid>(), It.IsAny<Guid>()));
         _dbContext.Setup(x => x.SaveChangesAsync(CancellationToken.None));
 
         // Act
         await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        _dbContext.Verify(x => x.DeleteExpense(It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Once());
+        _dbContext.Verify(x => x.DeleteExpenseAsync(It.IsAny<Guid>(), It.IsAny<Guid>()), Times.Once());
         _dbContext.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Once());
     }
 }

--- a/src/tests/budget/Budget.UnitTests/Expenses/Commands/UpdateExpenseCommandHandlerUnitTests.cs
+++ b/src/tests/budget/Budget.UnitTests/Expenses/Commands/UpdateExpenseCommandHandlerUnitTests.cs
@@ -11,7 +11,7 @@ public sealed class UpdateExpenseCommandHandlerUnitTests
     }
 
     [Fact]
-    public async Task Handle_ExpenseDoesNotExist_ThrowsExpenseException()
+    public async Task Handle_UpdateExpenseFails_ThrowsExpenseException()
     {
         // Arrange
         UpdateExpenseCommand command = new(Guid.NewGuid(), Guid.NewGuid(), 1000, "PHP", DateTime.UtcNow.ToShortDateString(), "Test Expense", Guid.NewGuid().ToString());
@@ -27,23 +27,7 @@ public sealed class UpdateExpenseCommandHandlerUnitTests
     }
 
     [Fact]
-    public async Task Handle_ExpenseCategoryDoesNotExist_ThrowsExpenseException()
-    {
-        // Arrange
-        UpdateExpenseCommand command = new(Guid.NewGuid(), Guid.NewGuid(), 1000, "PHP", DateTime.UtcNow.ToShortDateString(), "Test Expense", Guid.NewGuid().ToString());
-        _dbContext.Setup(x => x.UpdateExpenseAsync(It.IsAny<Expense>()))
-            .ThrowsAsync(new ExpenseException("Invalid expense category"));
-
-        // Act
-        await Assert.ThrowsAsync<ExpenseException>(() => _handler.Handle(command, CancellationToken.None));
-
-        // Assert
-        _dbContext.Verify(x => x.UpdateExpenseAsync(It.IsAny<Expense>()), Times.Once());
-        _dbContext.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Never());
-    }
-
-    [Fact]
-    public async Task Handle_ExpenseDataIsValid_UpdateAndSaveExpense()
+    public async Task Handle_UpdateExpenseSucceed_SaveChanges()
     {
         // Arrange
         UpdateExpenseCommand command = new(Guid.NewGuid(), Guid.NewGuid(), 1000, "PHP", DateTime.UtcNow.ToShortDateString(), "Test Expense", Guid.NewGuid().ToString());

--- a/src/tests/budget/Budget.UnitTests/Expenses/Commands/UpdateExpenseCommandHandlerUnitTests.cs
+++ b/src/tests/budget/Budget.UnitTests/Expenses/Commands/UpdateExpenseCommandHandlerUnitTests.cs
@@ -15,14 +15,14 @@ public sealed class UpdateExpenseCommandHandlerUnitTests
     {
         // Arrange
         UpdateExpenseCommand command = new(Guid.NewGuid(), Guid.NewGuid(), 1000, "PHP", DateTime.UtcNow.ToShortDateString(), "Test Expense", Guid.NewGuid().ToString());
-        _dbContext.Setup(x => x.UpdateExpense(It.IsAny<Expense>()))
+        _dbContext.Setup(x => x.UpdateExpenseAsync(It.IsAny<Expense>()))
             .ThrowsAsync(new ExpenseException("Invalid expense"));
 
         // Act
         await Assert.ThrowsAsync<ExpenseException>(() => _handler.Handle(command, CancellationToken.None));
 
         // Assert
-        _dbContext.Verify(x => x.UpdateExpense(It.IsAny<Expense>()), Times.Once());
+        _dbContext.Verify(x => x.UpdateExpenseAsync(It.IsAny<Expense>()), Times.Once());
         _dbContext.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Never());
     }
 
@@ -31,14 +31,14 @@ public sealed class UpdateExpenseCommandHandlerUnitTests
     {
         // Arrange
         UpdateExpenseCommand command = new(Guid.NewGuid(), Guid.NewGuid(), 1000, "PHP", DateTime.UtcNow.ToShortDateString(), "Test Expense", Guid.NewGuid().ToString());
-        _dbContext.Setup(x => x.UpdateExpense(It.IsAny<Expense>()))
+        _dbContext.Setup(x => x.UpdateExpenseAsync(It.IsAny<Expense>()))
             .ThrowsAsync(new ExpenseException("Invalid expense category"));
 
         // Act
         await Assert.ThrowsAsync<ExpenseException>(() => _handler.Handle(command, CancellationToken.None));
 
         // Assert
-        _dbContext.Verify(x => x.UpdateExpense(It.IsAny<Expense>()), Times.Once());
+        _dbContext.Verify(x => x.UpdateExpenseAsync(It.IsAny<Expense>()), Times.Once());
         _dbContext.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Never());
     }
 
@@ -47,14 +47,14 @@ public sealed class UpdateExpenseCommandHandlerUnitTests
     {
         // Arrange
         UpdateExpenseCommand command = new(Guid.NewGuid(), Guid.NewGuid(), 1000, "PHP", DateTime.UtcNow.ToShortDateString(), "Test Expense", Guid.NewGuid().ToString());
-        _dbContext.Setup(x => x.UpdateExpense(It.IsAny<Expense>()));
+        _dbContext.Setup(x => x.UpdateExpenseAsync(It.IsAny<Expense>()));
         _dbContext.Setup(x => x.SaveChangesAsync(CancellationToken.None));
 
         // Act
         await _handler.Handle(command, CancellationToken.None);
 
         // Assert
-        _dbContext.Verify(x => x.UpdateExpense(It.IsAny<Expense>()), Times.Once());
+        _dbContext.Verify(x => x.UpdateExpenseAsync(It.IsAny<Expense>()), Times.Once());
         _dbContext.Verify(x => x.SaveChangesAsync(CancellationToken.None), Times.Once());
     }
 }

--- a/src/tests/budget/Budget.UnitTests/Expenses/Queries/GetExpensesQueryHandlerTests.cs
+++ b/src/tests/budget/Budget.UnitTests/Expenses/Queries/GetExpensesQueryHandlerTests.cs
@@ -24,6 +24,7 @@ public sealed class GetExpensesQueryHandlerTests
         // Assert
         _repository.Verify(x => x.GetAllAsync(It.IsAny<Guid>(), CancellationToken.None), Times.Once());
         Assert.IsType<List<ExpenseSummaryDto>>(result);
+        Assert.Empty(result);
     }
 
     [Fact]
@@ -43,6 +44,7 @@ public sealed class GetExpensesQueryHandlerTests
         // Assert
         _repository.Verify(x => x.GetAllAsync(It.IsAny<Guid>(), CancellationToken.None), Times.Once());
         Assert.IsType<List<ExpenseSummaryDto>>(result);
+        Assert.NotEmpty(result);
         Assert.Equal(3, result.Count);
     }
 }

--- a/src/tests/budget/Budget.UnitTests/GlobalUsings.cs
+++ b/src/tests/budget/Budget.UnitTests/GlobalUsings.cs
@@ -1,3 +1,6 @@
+global using Budget.Application.ExpenseCategories;
+global using Budget.Application.ExpenseCategories.GetAll;
+global using Budget.Application.ExpenseCategories.GetById;
 global using Budget.Application.Expenses;
 global using Budget.Application.Expenses.Create;
 global using Budget.Application.Expenses.Delete;

--- a/src/tests/budget/Budget.UnitTests/GlobalUsings.cs
+++ b/src/tests/budget/Budget.UnitTests/GlobalUsings.cs
@@ -1,4 +1,5 @@
 global using Budget.Application.ExpenseCategories;
+global using Budget.Application.ExpenseCategories.Create;
 global using Budget.Application.ExpenseCategories.GetAll;
 global using Budget.Application.ExpenseCategories.GetById;
 global using Budget.Application.Expenses;

--- a/src/tests/budget/Budget.UnitTests/GlobalUsings.cs
+++ b/src/tests/budget/Budget.UnitTests/GlobalUsings.cs
@@ -2,6 +2,7 @@ global using Budget.Application.ExpenseCategories;
 global using Budget.Application.ExpenseCategories.Create;
 global using Budget.Application.ExpenseCategories.GetAll;
 global using Budget.Application.ExpenseCategories.GetById;
+global using Budget.Application.ExpenseCategories.Update;
 global using Budget.Application.Expenses;
 global using Budget.Application.Expenses.Create;
 global using Budget.Application.Expenses.Delete;

--- a/src/tests/budget/Budget.UnitTests/GlobalUsings.cs
+++ b/src/tests/budget/Budget.UnitTests/GlobalUsings.cs
@@ -1,5 +1,6 @@
 global using Budget.Application.ExpenseCategories;
 global using Budget.Application.ExpenseCategories.Create;
+global using Budget.Application.ExpenseCategories.Delete;
 global using Budget.Application.ExpenseCategories.GetAll;
 global using Budget.Application.ExpenseCategories.GetById;
 global using Budget.Application.ExpenseCategories.Update;


### PR DESCRIPTION
- Added the ff. endpoints:
  - Get all expense categories: `GET: /api/expense-categories`
  - Get expense category by id: `GET: /api/expense-categories/{id}`
  - Create expense category: `POST: /api/expense-categories`
  - Update expense category: `PUT: /api/expense-categories/{id}`
  - Delete expense category: `DELETE: /api/expense-categories/{id}`
- Added unit tests for expense categories
- Refactor code solution